### PR TITLE
Fix typo in Metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,4 +16,4 @@ galaxy_info:
         - squeeze
   categories:
     - database
-dependecies: []
+dependencies: []


### PR DESCRIPTION
This typo leads to

```
ERROR! 'dependecies' is not a valid attribute for a RoleMetadata

The error appears to have been in '/***/roles/percona/meta/main.yml': line 2, column
1, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

---
galaxy_info:
^ here

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```
